### PR TITLE
Add required Send bounds on the constructor method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ pub trait ParallelIteratorExt: ParallelIterator {
     where
         Output: Send,
         Target: Default + Send + 't,
-        Mapfold: Clone + Fn(&mut Target, Self::Item) -> Output,
-        Reduce: Clone + Fn(&mut Target, Target),
+        Mapfold: Clone + Fn(&mut Target, Self::Item) -> Output + Send,
+        Reduce: Clone + Fn(&mut Target, Target) + Send,
     {
         MapfoldReduce {
             target: target,


### PR DESCRIPTION
Without them, the return type does not implement anything useful. Having them repeated here makes error messages much clearer in generic code.